### PR TITLE
fix: correct chart rerendering

### DIFF
--- a/src/components/Index.js
+++ b/src/components/Index.js
@@ -41,7 +41,10 @@ class Index extends Component {
       }
 
     changeFocus(meal) {
-        this.setState({chosenMeal: meal})
+        if(this.state.chosenMeal !== meal) {
+            // If the current meal is not equal to the new selection update the state and cause a re-render
+            this.setState({chosenMeal: meal});
+        }
     }
 
     handleSubmit(event) {

--- a/src/components/PieChart.js
+++ b/src/components/PieChart.js
@@ -14,22 +14,59 @@ class PieChart extends Component {
                 carbs_g: '',
                 fat_g: '',
                 protein_g: '',
-            }
+            },
+            mealsChart: null,
         }
     }
 
     componentDidMount() {
-        this.getData();
+        this.createChart();
     }  
 
     componentDidUpdate(){
-        this.getData();
+        this.updateChart();
     }
 
-    getData() {
-        const chartData = this.prepareData(this.props.meal);
-        this.createChart(chartData);
+    createChart = () => {
+        // create a query selector for the canvas
+        const ctx = document.querySelector('#meals');
+        
+        // Create a new chart with empty data
+        const mealsChart = new Chart(ctx, {
+            type: 'pie',
+            data: {},
+            options: {                
+                animation: {
+                    animateScale: true,                    
+                    duration: 2000
+                },
+                legend: {
+                    labels: {
+                        fontColor: 'white'                        
+                    }
+                }
+            }            
+        });
 
+        // Store this chart object in state
+        this.setState({mealsChart})
+    }
+
+    updateChart() {
+        // Get chart data for specific meal prop
+        const chartData = this.prepareData(this.props.meal);
+        // pull chart object out of current state
+        const { mealsChart } = this.state;
+
+        // Replace current data with updated data.
+        // NOTE: this goes against their documentation
+        // Their recommendation is to remove all elements from the array with .pop()
+        // Then add the new elements with .push()
+        // TODO: update this to not reassign data
+        mealsChart.data = chartData;
+
+        // Call update on the chart object triggering a re-render
+        mealsChart.update();
     }
 
     prepareData = (meal) => {
@@ -57,28 +94,6 @@ class PieChart extends Component {
         chartData.datasets[0].data.push(meal.fat_g)
         chartData.datasets[0].data.push(meal.protein_g)  
         return chartData
-    }
-
-    createChart = (data) => {
-        const ctx = document.querySelector('#meals');
-        
-        let mealsChart = new Chart(ctx, {
-            type: 'pie',
-            data: data,
-            options: {
-                
-                animation: {
-                    animateScale: true,
-                    
-                    duration: 2000
-                },
-                legend: {
-                    labels: {
-                        fontColor: 'white'                        
-                    }
-                }
-            }            
-        })
     }
 
     render () {


### PR DESCRIPTION
## Why is this change happening?

The chart that is rendered on the screen is re-created every time we call `componentDidUpdate()` in the react lifecycle.

The Charts.js documentation shows they support [updating an existing chart](https://www.chartjs.org/docs/latest/developers/updates.html), so I've changed the logic slightly to create the chart once in `componentDidMount()` and then update the data and call `.update()` in `componentDidUpdate()`

I also saw that when clicking the same menu item it would trigger a rerender because the state was being updated with the same value.  To prevent this I updated the logic in `changeFocus()` to only call `this.setState()` if the meal has actually changed.